### PR TITLE
Add source dependencies by file protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 .idea/
 *.sqlite3
 **/__pycache__/**
+.venv/*
+test-data/sdists/sdist_archive/*
+venv/*
+test-data/sdists/*

--- a/crates/rattler_installs_packages/src/artifacts/sdist.rs
+++ b/crates/rattler_installs_packages/src/artifacts/sdist.rs
@@ -59,7 +59,6 @@ impl SDist {
         let name =
             SDistFilename::from_filename(file_name, normalized_package_name).into_diagnostic();
         if let Ok(name) = name {
-            println!("GOT FROM FILENAME");
             Self::new(name, Box::new(bytes))
         } else {
             // we cannot create fast from filename

--- a/crates/rattler_installs_packages/src/artifacts/sdist.rs
+++ b/crates/rattler_installs_packages/src/artifacts/sdist.rs
@@ -6,7 +6,8 @@ use miette::IntoDiagnostic;
 use parking_lot::{Mutex, MutexGuard};
 use serde::Serialize;
 use std::ffi::OsStr;
-use std::io::{ErrorKind, Read, Seek};
+use std::fs::{read_dir, File};
+use std::io::{Error, ErrorKind, Read, Seek};
 use std::path::{Path, PathBuf};
 use tar::Archive;
 
@@ -54,10 +55,42 @@ impl SDist {
             .file_name()
             .and_then(OsStr::to_str)
             .ok_or_else(|| miette::miette!("path does not contain a filename"))?;
-        let name =
-            SDistFilename::from_filename(file_name, normalized_package_name).into_diagnostic()?;
         let bytes = std::fs::File::open(path).into_diagnostic()?;
-        Self::new(name, Box::new(bytes))
+        let name =
+            SDistFilename::from_filename(file_name, normalized_package_name).into_diagnostic();
+        if let Ok(name) = name {
+            println!("GOT FROM FILENAME");
+            Self::new(name, Box::new(bytes))
+        } else {
+            // we cannot create fast from filename
+            // rely on project metadata
+            Self::from_metadata(file_name, normalized_package_name, bytes)
+        }
+    }
+
+    /// Create SDist directly from archive metadata
+    pub fn from_metadata(
+        file_name: &str,
+        normalized_package_name: &NormalizedPackageName,
+        bytes: File,
+    ) -> miette::Result<Self> {
+        // create a dummy_sdist_name
+        let dummy_sdist_name = SDistFilename::new(
+            normalized_package_name.clone().to_string(),
+            String::from("0.0.0"),
+            SDistFilename::get_extension(file_name).into_diagnostic()?,
+        )
+        .into_diagnostic()?;
+        let mut dummy_sdist = Self::new(dummy_sdist_name, Box::new(bytes))?;
+        // read package info
+        let (_, metadata) = dummy_sdist.read_package_info().into_diagnostic()?;
+        // map correct values here
+        let original_name = metadata.name;
+        let original_version = metadata.version;
+        dummy_sdist.name.distribution = original_name;
+        dummy_sdist.name.version = original_version;
+
+        Ok(dummy_sdist)
     }
 
     /// Find entry in tar archive

--- a/crates/rattler_installs_packages/src/index/package_database.rs
+++ b/crates/rattler_installs_packages/src/index/package_database.rs
@@ -2,7 +2,10 @@ use crate::artifacts::{SDist, Wheel};
 use crate::index::file_store::FileStore;
 use crate::index::html::{parse_package_names_html, parse_project_info_html};
 use crate::index::http::{CacheMode, Http, HttpRequestError};
-use crate::types::{ArtifactInfo, ProjectInfo, WheelCoreMetadata};
+use crate::types::{
+    ArtifactHashes, ArtifactInfo, ArtifactName, DistInfoMetadata, PackageName, ProjectInfo,
+    SDistFilename, WheelCoreMetadata, Yanked,
+};
 use crate::wheel_builder::WheelBuilder;
 use crate::{
     types::Artifact, types::InnerAsArtifactName, types::NormalizedPackageName, types::Version,
@@ -11,13 +14,21 @@ use crate::{
 use async_http_range_reader::{AsyncHttpRangeReader, CheckSupportMethod};
 use async_recursion::async_recursion;
 use elsa::sync::FrozenMap;
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use futures::{pin_mut, stream, StreamExt};
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, Method};
 use indexmap::IndexMap;
 use miette::{self, Diagnostic, IntoDiagnostic};
+use rattler_digest::{compute_bytes_digest, compute_file_digest, Sha256};
 use reqwest::{header::CACHE_CONTROL, Client, StatusCode};
+use std::collections::HashMap;
+use std::env;
+use std::fs::File;
 use std::path::PathBuf;
+use std::time::SystemTime;
 use std::{fmt::Display, io::Read, path::Path};
+use tempfile::tempdir;
 use url::Url;
 
 /// Cache of the available packages, artifacts and their metadata.
@@ -56,6 +67,123 @@ impl PackageDb {
     /// Returns the cache directory
     pub fn cache_dir(&self) -> &Path {
         &self.cache_dir
+    }
+
+    /// compress an sdist to dir
+    /// TODO: refactor into a better place
+    /// TODO: x2 should it even exists?
+    pub fn compress_sdist_dir(&self, sdist_path: &Path, into_archive_path: &Path) -> PathBuf {
+        // compress dir into .tar
+        let full_path = into_archive_path.join("archive_sdist.tar.gz");
+        let full_path_str = full_path.as_path();
+        let tar_gz = File::create(full_path_str).unwrap();
+        let enc = GzEncoder::new(tar_gz, Compression::default());
+        let mut tar = tar::Builder::new(enc);
+        tar.append_dir_all(".", sdist_path).unwrap();
+
+        full_path_str.to_path_buf()
+    }
+
+    /// Get artifact by file URL
+    pub async fn get_file_artifact<'a, 'i, P: Into<NormalizedPackageName>>(
+        &self,
+        p: P,
+        url: Url,
+        wheel_builder: &WheelBuilder<'a, 'i>,
+    ) -> miette::Result<&IndexMap<Version, Vec<ArtifactInfo>>> {
+        let str_name = url.path();
+        let path = Path::new(str_name);
+
+        let normalized_package_name = p.into();
+
+        let (sdist, data) = match path.is_file() {
+            true => {
+                let sdist: SDist =
+                    SDist::from_path(&path, &normalized_package_name.clone()).unwrap();
+                // get directly name and version
+                let data = sdist.read_package_info().unwrap();
+                (sdist, data)
+            }
+            false => {
+                // compress dir into .tar, and work with it as it is a simple sdist
+                // should it even be done?
+                // maybe we can work with dir directly
+                let tmpdir = tempdir().unwrap();
+                let tar_path = self.compress_sdist_dir(path, tmpdir.path());
+                println!("TAR PATH EXISTS ? {:?}", tar_path.exists());
+                let sdist: SDist =
+                    SDist::from_path(&tar_path, &normalized_package_name.clone()).unwrap();
+
+                let data = wheel_builder.get_sdist_metadata(&sdist).await.unwrap();
+                (sdist, data)
+            }
+        };
+
+        let (bytes, metadata) = data;
+
+        let sdist_file_name = sdist.name();
+
+        let filename = ArtifactName::SDist(sdist_file_name.clone());
+
+        let requires_python = metadata.requires_python;
+
+        let dist_info_metadata = DistInfoMetadata {
+            available: false,
+            hashes: ArtifactHashes::default(),
+        };
+
+        let yanked = Yanked {
+            yanked: false,
+            reason: None,
+        };
+
+        let project_hash = ArtifactHashes {
+            sha256: Some(compute_bytes_digest::<Sha256>(url.as_str().as_bytes())),
+        };
+
+        // let's try to build an artifact info :)
+        let artifact_info = ArtifactInfo {
+            filename,
+            url: url.clone(),
+            hashes: Some(project_hash),
+            requires_python,
+            dist_info_metadata,
+            yanked,
+        };
+
+        let mut result: IndexMap<Version, Vec<ArtifactInfo>> = Default::default();
+        // let url_entry =
+        result
+            .entry(artifact_info.filename.version().clone())
+            .or_default()
+            .push(artifact_info.clone());
+
+        self.put_metadata_in_cache(&artifact_info, &bytes).await?;
+
+        Ok(self
+            .artifacts
+            .insert(normalized_package_name.clone(), Box::new(result)))
+    }
+
+    /// Get artifact directly from file, vcs, or url
+    pub async fn get_artifact_by_url<'a, 'i, P: Into<NormalizedPackageName>>(
+        &self,
+        p: P,
+        url: Url,
+        wheel_builder: &WheelBuilder<'a, 'i>,
+    ) -> miette::Result<&IndexMap<Version, Vec<ArtifactInfo>>> {
+        //conver to str
+        let p = p.into();
+
+        if let Some(cached) = self.artifacts.get(&p) {
+            Ok(cached)
+        } else {
+            if url.scheme() == "file" {
+                self.get_file_artifact(p, url, wheel_builder).await
+            } else {
+                unimplemented!("it's not implemented yet");
+            }
+        }
     }
 
     /// Downloads and caches information about available artifiacts of a package from the index.

--- a/crates/rattler_installs_packages/src/index/package_database.rs
+++ b/crates/rattler_installs_packages/src/index/package_database.rs
@@ -110,7 +110,6 @@ impl PackageDb {
                 // maybe we can work with dir directly
                 let tmpdir = tempdir().unwrap();
                 let tar_path = self.compress_sdist_dir(path, tmpdir.path());
-                println!("TAR PATH EXISTS ? {:?}", tar_path.exists());
                 let sdist: SDist =
                     SDist::from_path(&tar_path, &normalized_package_name.clone()).unwrap();
 

--- a/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
+++ b/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
@@ -358,10 +358,7 @@ impl<'p> DependencyProvider<PypiVersionSet, PypiPackageName>
 
         // check if we have URL variant for this name
         let url_version = self.name_to_url.get(package_name.base());
-        println!(
-            "Should collect package name and version {:?} {:?}",
-            package_name, url_version
-        );
+
 
         let result = match url_version {
             Some(url) => {

--- a/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
+++ b/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
@@ -1,4 +1,5 @@
 use super::SDistResolution;
+use crate::artifacts;
 use crate::artifacts::SDist;
 use crate::artifacts::Wheel;
 use crate::index::PackageDb;
@@ -46,10 +47,12 @@ impl Display for PypiVersionSet {
 
 /// This is a wrapper around [`Version`] that serves a version
 /// within the [`PypiVersionSet`] version set.
-#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub(crate) enum PypiVersion {
+    /// A Version
     Version(Version),
     #[allow(dead_code)]
+    /// A url
     Url(Url),
 }
 
@@ -77,7 +80,7 @@ impl Display for PypiVersion {
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Clone)]
+#[derive(PartialEq, Eq, Hash, Clone, Debug)]
 /// This can either be a base package name or with an extra
 /// this is used to support optional dependencies
 pub(crate) enum PypiPackageName {
@@ -123,6 +126,7 @@ pub(crate) struct PypiDependencyProvider<'db, 'i> {
     compatible_tags: Option<&'i WheelTags>,
 
     pub cached_artifacts: FrozenMap<SolvableId, Vec<&'db ArtifactInfo>>,
+    name_to_url: HashMap<NormalizedPackageName, Url>,
 
     favored_packages: HashMap<NormalizedPackageName, PinnedPackage<'db>>,
     locked_packages: HashMap<NormalizedPackageName, PinnedPackage<'db>>,
@@ -134,9 +138,11 @@ impl<'db, 'i> PypiDependencyProvider<'db, 'i> {
     /// Creates a new PypiDependencyProvider
     /// for use with the [`resolvo`] crate
     pub fn new(
+        pool: Pool<PypiVersionSet, PypiPackageName>,
         package_db: &'db PackageDb,
         markers: &'i MarkerEnvironment,
         compatible_tags: Option<&'i WheelTags>,
+        name_to_url: HashMap<NormalizedPackageName, Url>,
         locked_packages: HashMap<NormalizedPackageName, PinnedPackage<'db>>,
         favored_packages: HashMap<NormalizedPackageName, PinnedPackage<'db>>,
         options: &'i ResolveOptions,
@@ -152,12 +158,13 @@ impl<'db, 'i> PypiDependencyProvider<'db, 'i> {
         );
 
         Ok(Self {
-            pool: Pool::new(),
+            pool,
             package_db,
             wheel_builder,
             markers,
             compatible_tags,
             cached_artifacts: Default::default(),
+            name_to_url,
             favored_packages,
             locked_packages,
             options,
@@ -349,13 +356,39 @@ impl<'p> DependencyProvider<PypiVersionSet, PypiPackageName>
         let package_name = self.pool.resolve_package_name(name);
         tracing::info!("collecting {}", package_name);
 
-        // Get all the metadata for this package
-        let result = task::block_in_place(move || {
-            Handle::current().block_on(
-                self.package_db
-                    .available_artifacts(package_name.base().clone()),
-            )
-        });
+        // check if we have URL variant for this name
+        let url_version = self.name_to_url.get(package_name.base());
+        println!(
+            "Should collect package name and version {:?} {:?}",
+            package_name, url_version
+        );
+
+        let result = match url_version {
+            Some(url) => {
+                let result = task::block_in_place(move || {
+                    Handle::current().block_on(self.package_db.get_artifact_by_url(
+                        package_name.base().clone(),
+                        url.clone(),
+                        &self.wheel_builder,
+                    ))
+                });
+                result
+            }
+            None => {
+                // Get all the metadata for this package
+                let result: Result<
+                    &indexmap::IndexMap<Version, Vec<ArtifactInfo>>,
+                    miette::ErrReport,
+                > = task::block_in_place(move || {
+                    Handle::current().block_on(
+                        self.package_db
+                            .available_artifacts(package_name.base().clone()),
+                    )
+                });
+                result
+            }
+        };
+
         let artifacts = match result {
             Ok(artifacts) => artifacts,
             Err(err) => {
@@ -365,22 +398,26 @@ impl<'p> DependencyProvider<PypiVersionSet, PypiPackageName>
                 return None;
             }
         };
+
         let mut candidates = Candidates::default();
         let locked_package = self.locked_packages.get(package_name.base());
         let favored_package = self.favored_packages.get(package_name.base());
         for (version, artifacts) in artifacts.iter() {
             // Skip this version if a locked or favored version exists for this version. It will be
             // added below.
-            if locked_package.map(|p| &p.version) == Some(version)
+            if locked_package.map(|p: &PinnedPackage<'_>| &p.version) == Some(version)
                 || favored_package.map(|p| &p.version) == Some(version)
             {
                 continue;
             }
 
+            let original_version = match self.name_to_url.get(package_name.base()) {
+                Some(version) => PypiVersion::Url(version.clone()),
+                None => PypiVersion::Version(version.clone()),
+            };
+
             // Add the solvable
-            let solvable_id = self
-                .pool
-                .intern_solvable(name, PypiVersion::Version(version.clone()));
+            let solvable_id = self.pool.intern_solvable(name, original_version);
             candidates.candidates.push(solvable_id);
 
             // Determine the candidates
@@ -424,9 +461,7 @@ impl<'p> DependencyProvider<PypiVersionSet, PypiPackageName>
     fn get_dependencies(&self, solvable_id: SolvableId) -> Dependencies {
         let solvable = self.pool.resolve_solvable(solvable_id);
         let package_name = self.pool.resolve_package_name(solvable.name_id());
-        let PypiVersion::Version(package_version) = solvable.inner() else {
-            unimplemented!("cannot get dependencies of wheels by url yet")
-        };
+        let package_version = solvable.inner();
 
         tracing::info!(
             "obtaining dependency information from {}={}",
@@ -443,16 +478,29 @@ impl<'p> DependencyProvider<PypiVersionSet, PypiPackageName>
                 .pool
                 .lookup_package_name(&PypiPackageName::Base(package_name.clone()))
                 .expect("base package not found while resolving extra");
-            let specifiers = VersionSpecifiers::from_iter([VersionSpecifier::new(
-                Operator::ExactEqual,
-                package_version.clone(),
-                false,
-            )
-            .expect("failed to construct equality version specifier")]);
-            let version_set_id = self.pool.intern_version_set(
-                base_name_id,
-                Some(VersionOrUrl::VersionSpecifier(specifiers)).into(),
-            );
+            let version_set_id = match package_version {
+                PypiVersion::Version(version) => {
+                    let specifiers = VersionSpecifiers::from_iter([VersionSpecifier::new(
+                        Operator::ExactEqual,
+                        version.clone(),
+                        false,
+                    )
+                    .expect("failed to construct equality version specifier")]);
+                    let version_set_id = self.pool.intern_version_set(
+                        base_name_id,
+                        Some(VersionOrUrl::VersionSpecifier(specifiers)).into(),
+                    );
+                    version_set_id
+                }
+                PypiVersion::Url(url_version) => {
+                    let version_set_id = self.pool.intern_version_set(
+                        base_name_id,
+                        Some(VersionOrUrl::Url(url_version.clone())).into(),
+                    );
+                    version_set_id
+                }
+            };
+
             dependencies.requirements.push(version_set_id);
         }
 
@@ -489,16 +537,30 @@ impl<'p> DependencyProvider<PypiVersionSet, PypiPackageName>
                 let extra_name_id = self
                     .pool
                     .intern_package_name(PypiPackageName::Extra(package_name.clone(), extra));
-                let specifiers = VersionSpecifiers::from_iter([VersionSpecifier::new(
-                    Operator::ExactEqual,
-                    package_version.clone(),
-                    false,
-                )
-                .expect("failed to construct equality version specifier")]);
-                let version_set_id = self.pool.intern_version_set(
-                    extra_name_id,
-                    Some(VersionOrUrl::VersionSpecifier(specifiers)).into(),
-                );
+
+                let version_set_id = match package_version {
+                    PypiVersion::Version(version) => {
+                        let specifiers = VersionSpecifiers::from_iter([VersionSpecifier::new(
+                            Operator::ExactEqual,
+                            version.clone(),
+                            false,
+                        )
+                        .expect("failed to construct equality version specifier")]);
+                        let version_set_id = self.pool.intern_version_set(
+                            extra_name_id,
+                            Some(VersionOrUrl::VersionSpecifier(specifiers)).into(),
+                        );
+                        version_set_id
+                    }
+                    PypiVersion::Url(url_version) => {
+                        let version_set_id = self.pool.intern_version_set(
+                            extra_name_id,
+                            Some(VersionOrUrl::Url(url_version.clone())).into(),
+                        );
+                        version_set_id
+                    }
+                };
+
                 dependencies.constrains.push(version_set_id);
             }
         }

--- a/crates/rattler_installs_packages/src/resolve/solve.rs
+++ b/crates/rattler_installs_packages/src/resolve/solve.rs
@@ -253,16 +253,6 @@ pub async fn resolve<'db>(
             }
         };
 
-        // let PypiVersion::Version(version) = solvable.inner() else {
-        //     println!("IM NOT SUPPORTED YET but I will try to get version");
-
-        //     let artifacts = provider.cached_artifacts.get(&solvable_id).unwrap();
-        //     let artifact = artifacts[0];
-
-        //     PypiVersion::Version(artifact.filename.version())
-
-        //     // unreachable!("urls are not yet supported")
-        // };
 
         // Get the entry in the result
         let entry = result

--- a/crates/rattler_installs_packages/src/resolve/solve.rs
+++ b/crates/rattler_installs_packages/src/resolve/solve.rs
@@ -1,13 +1,14 @@
-use super::dependency_provider::PypiPackageName;
+use super::dependency_provider::{PypiPackageName, PypiVersionSet};
 use crate::index::PackageDb;
 use crate::python_env::{PythonLocation, WheelTags};
 use crate::resolve::dependency_provider::{PypiDependencyProvider, PypiVersion};
 use crate::types::PackageName;
 use crate::{types::ArtifactInfo, types::Extra, types::NormalizedPackageName, types::Version};
-use pep508_rs::{MarkerEnvironment, Requirement};
-use resolvo::{DefaultSolvableDisplay, Solver};
+use pep508_rs::{MarkerEnvironment, Requirement, VersionOrUrl};
+use resolvo::{DefaultSolvableDisplay, Pool, Solver};
 use std::collections::HashMap;
 use std::str::FromStr;
+use url::Url;
 
 use std::collections::HashSet;
 
@@ -170,19 +171,13 @@ pub async fn resolve<'db>(
     options: &ResolveOptions,
     python_location: PythonLocation,
 ) -> miette::Result<Vec<PinnedPackage<'db>>> {
-    // Construct a provider
-    let provider = PypiDependencyProvider::new(
-        package_db,
-        env_markers,
-        compatible_tags,
-        locked_packages,
-        favored_packages,
-        options,
-        python_location,
-    )?;
-    let pool = &provider.pool;
+    //construct a pool
+    let pool: Pool<PypiVersionSet, PypiPackageName> = Pool::new();
 
     let requirements = requirements.into_iter();
+
+    // let construct hashmap
+    let mut name_to_url: HashMap<NormalizedPackageName, Url> = Default::default();
 
     // Construct the root requirements from the requirements requested by the user.
     let requirement_count = requirements.size_hint();
@@ -196,11 +191,15 @@ pub async fn resolve<'db>(
     } in requirements
     {
         let name = PackageName::from_str(name).expect("invalid package name");
-        let dependency_package_name =
-            pool.intern_package_name(PypiPackageName::Base(name.clone().into()));
+        let pypi_name = PypiPackageName::Base(name.clone().into());
+        let dependency_package_name = pool.intern_package_name(pypi_name.clone());
         let version_set_id =
             pool.intern_version_set(dependency_package_name, version_or_url.clone().into());
         root_requirements.push(version_set_id);
+
+        if let Some(VersionOrUrl::Url(url)) = version_or_url {
+            name_to_url.insert(pypi_name.base().clone(), url.clone());
+        }
 
         for extra in extras.iter().flatten() {
             let extra: Extra = extra.parse().expect("invalid extra");
@@ -211,6 +210,19 @@ pub async fn resolve<'db>(
             root_requirements.push(version_set_id);
         }
     }
+
+    // Construct a provider
+    let provider = PypiDependencyProvider::new(
+        pool,
+        package_db,
+        env_markers,
+        compatible_tags,
+        name_to_url,
+        locked_packages,
+        favored_packages,
+        options,
+        python_location,
+    )?;
 
     // Invoke the solver to get a solution to the requirements
     let mut solver = Solver::new(&provider);
@@ -231,9 +243,26 @@ pub async fn resolve<'db>(
         let pool = solver.pool();
         let solvable = pool.resolve_solvable(solvable_id);
         let name = pool.resolve_package_name(solvable.name_id());
-        let PypiVersion::Version(version) = solvable.inner() else {
-            unreachable!("urls are not yet supported")
+        let version = match solvable.inner() {
+            PypiVersion::Version(version) => version,
+            PypiVersion::Url(_) => {
+                let artifacts = provider.cached_artifacts.get(&solvable_id).unwrap();
+                let artifact = artifacts[0];
+
+                artifact.filename.version()
+            }
         };
+
+        // let PypiVersion::Version(version) = solvable.inner() else {
+        //     println!("IM NOT SUPPORTED YET but I will try to get version");
+
+        //     let artifacts = provider.cached_artifacts.get(&solvable_id).unwrap();
+        //     let artifact = artifacts[0];
+
+        //     PypiVersion::Version(artifact.filename.version())
+
+        //     // unreachable!("urls are not yet supported")
+        // };
 
         // Get the entry in the result
         let entry = result

--- a/crates/rattler_installs_packages/src/wheel_builder/build_environment.rs
+++ b/crates/rattler_installs_packages/src/wheel_builder/build_environment.rs
@@ -10,6 +10,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::str::FromStr;
+use std::{env, fs};
 
 // include static build_frontend.py string
 const BUILD_FRONTEND_PY: &str = include_str!("./wheel_builder_frontend.py");
@@ -138,6 +139,10 @@ impl<'db> BuildEnvironment<'db> {
     /// Run a command in the build environment
     pub(crate) fn run_command(&self, stage: &str) -> std::io::Result<Output> {
         // three args: cache.folder, goal
+        if !self.package_dir.exists() {
+            fs::create_dir(&self.package_dir)?;
+        }
+
         Command::new(self.venv.python_executable())
             .current_dir(&self.package_dir)
             .arg(self.work_dir.path().join("build_frontend.py"))


### PR DESCRIPTION
Will close [#119 ](https://github.com/prefix-dev/rip/issues/119)

usage:

`rip rich@file:///path/to/your/sdists/rich.tar.gz // will support usage without version in name`
`rip rich@file:///path/to/your/sdists/rich  // can point directly to dir`

- [ ] Decide how to handle directory with source ( convert to archive or add another layer of abstraction { file ( archive )  <-> dir }
- [ ]  replace unwraps with correct error handling
- [ ] Finalize source support by file
- [ ] Add source support by git
- [ ] Add source support by http/s 